### PR TITLE
Update analyzer references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,11 +8,16 @@
 
     <IntermediateOutputPath>..\..\artifacts\intermediates\$(Platform)\$(MSBuildProjectName)\</IntermediateOutputPath>
     <GeneratedFilesDir>..\..\artifacts\intermediates\$(Platform)\$(MSBuildProjectName)\Generated Files\</GeneratedFilesDir>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
   <!-- Packages needed in every project -->
   <ItemGroup>
     <!-- Code analyzer -->
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2"/>
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.2"/>
   </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,6 @@
   <!-- Packages needed in every project -->
   <ItemGroup>
     <!-- Code analyzer -->
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2"/>
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.2"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1"/>
   </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,10 @@
 
       CA1716: Identifiers should not match keywords.
       Ignore reason: Where identifiers match keywords, they are extremely unlikely to be mistaken for the keyword. 
+      
+      CA9998: FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers'
+      Ignore reason: They don't seem to work well with UWP.
       -->
-
-    <NoWarn>;$(NoWarn);CA1303;CA1305;WMC1501;CS8305;CA1716</NoWarn>
+    <NoWarn>;$(NoWarn);CA1303;CA1305;WMC1501;CS8305;CA1716;CA9998</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR updates the analyzer references to also include the new .NET 5.0 analyzers so they run once they work with UWP or we switch to .NET 5.0